### PR TITLE
Fix server/Dockerfile "forbidden path outside the build context"

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.20-alpine as build
 WORKDIR /app
 
 # Copy the source code into the container
-COPY ../.. .
+COPY . .
 
 # Build the Go application
 RUN go build -o blood-info cmd/server/main.go


### PR DESCRIPTION
`docker-compose --env-file db.env up --build` suggested by README was failing with:

    Step 3/15 : COPY ../.. .
    COPY failed: forbidden path outside the build context: ../.. ()

I see that `docker build . -f cmd/scraper/Dockerfile` already works, so doing the same here.

There is no way for `COPY ../anything` to work; if the "context" directory is set to e.g.  `docker build cmd/server/` then the COPY source can only come from within cmd/server/.
This instead makes `docker build . -f cmd/server/Dockerfile` work, sending the whole project as the "context".
And now the docker-compose command also works as-is, yay!

@masayag please review