### PR TITLE
Add CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Edit or change the db.env file to your liking. Then, run the following command:
 ```bash
 docker-compose --env-file db.env up --build
 ```
+
+Note this generates a self-signed cert & key during the build, separate from anything you might have in cert.pem file.
+So once it built, you want to run this to get the same ./cert.pem:
+```
+docker run blood-donation-backend_blood-info /bin/cat cert.pem > cert.pem
+```
+
 ### Stopping the containers
 ```bash
 docker-compose --env-file db.env down --remove-orphans --volumes --rmi local

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=build /app/blood-info blood-info
 COPY --from=build /app/tls-self-signed-cert tls-self-signed-cert
 
 # FIXME: This is a hack to get the self-signed certificate to work. There must be a better way.
+# FIXME: This makes the secret `key.pem` also part of the image; uploading the image anywhere would leak it!
+# FIXME: any prior `cert.pem` & `key.pem` you had in current dir are *also* leaked in the COPY layer.
 RUN ./tls-self-signed-cert
 
 RUN addgroup -S gouser && adduser -S gouser -G gouser

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/oapi-codegen/nethttp-middleware v1.0.1
 	github.com/oapi-codegen/runtime v1.0.0
+	github.com/rs/cors v1.10.1
 	gorm.io/driver/postgres v1.5.3
 	gorm.io/gorm v1.25.5
 )

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
+github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=


### PR DESCRIPTION
Closes #29.  I hope.

Testing with this UI patch:
```diff
--- src/app/where/page.tsx
+++ src/app/where/page.tsx
@@ -43,7 +43,7 @@ export default function Where() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await fetch(`${process.env.API_URL}/schedule`)
+        const response = await fetch(`https://localhost:8443/schedule`)
         const fetchLocation = await response.json()
```
(setting API_URL seems not working right now)

## Result

| before | after |
|--------|-------|
| ![browser CORS errors](https://github.com/il-blood-donation-info/blood-donation-backend/assets/273688/4443df02-9dd2-449a-9aca-7137171c1dc1) | ![browser loads schedule](https://github.com/il-blood-donation-info/blood-donation-backend/assets/273688/8acda961-cfd7-426c-92c7-f2ad1aced91b) |
| ![curl no CORS](https://github.com/il-blood-donation-info/blood-donation-backend/assets/273688/d814ed20-56d6-4115-9410-b298fe714eee) | ![curl CORS headers](https://github.com/il-blood-donation-info/blood-donation-backend/assets/273688/624e99ce-8de6-4919-bf87-1be54585fadd) |

test commands used, for ["simple"](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests) vs. [preflight](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests) modes respectively:
```
curl -i --insecure -X GET -H 'Origin: foo.bar' https://localhost:8443/users
curl -i --insecure -X OPTIONS -H 'Origin: foo.bar' -H 'Access-Control-Request-Method: POST' -H 'Access-Control-Request-Headers: Content-Type' https://localhost:8443/users
```

----

* Also documented some issues with the self-signed cert (out of scope here).